### PR TITLE
Document the `cleanup` configuration variable

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -755,6 +755,20 @@ enabled             If ``true`` it will send HTTP POST requests to a given url.
 url                The url where to send HTTP POST requests (default: ``http:localhost``).
 ================== ================
 
+.. _config-miscellaneous:
+
+Miscellaneous
+-------------
+
+There are additional variables that can be defined within a configuration file that do not have a dedicated scope.
+
+These are defined alongside other scopes, but the option is assigned as typically variable.
+
+================== ================
+Name                Description
+================== ================
+cleanup             If ``true``, on a successful completion of a run all files in `work/` directory are automatically deleted. Note this means `-resume` cannot be subsequently used on that pipeline run.
+================== ================
 
 .. _config-profiles:
 


### PR DESCRIPTION
This documents the currently undocumented `cleanup` option that is avaliable in configuration files.

Based on the discussion on the nf-core slack originally [here](https://nfcore.slack.com/archives/CE56GDKN0/p1583244613045500) and more recently [here](https://nfcore.slack.com/archives/CE6P95170/p1622115069029300)

Note this is a draft as we are unsure if this still an incubating feature and also it is not a traditional 'scope'. However we were unsure where this would fit in the documentation - therefore feel free to move/update as necessary.

It would also potentially close [#452](https://github.com/nextflow-io/nextflow/issues/452)